### PR TITLE
Test enhancement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "guzzlehttp/guzzle": "^6.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Builder/AccountInfoBuilderTest.php
+++ b/tests/Builder/AccountInfoBuilderTest.php
@@ -12,13 +12,15 @@
 namespace Ideneal\OpenLoad\Test\Builder;
 
 use Ideneal\OpenLoad\Builder\AccountInfoBuilder;
+use Ideneal\OpenLoad\Entity\AccountInfo;
+use PHPUnit\Framework\TestCase;
 
 /**
  * AccountInfoBuilderTest
  *
  * @author Daniele Pedone aka Ideneal <ideneal.ztl@gmail.com>
  */
-class AccountInfoBuilderTest extends \PHPUnit_Framework_TestCase
+class AccountInfoBuilderTest extends TestCase
 {
     /**
      * @var string The account info result fixture
@@ -32,14 +34,14 @@ class AccountInfoBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $data    = json_decode($this->fixture, true);
         $account = AccountInfoBuilder::buildAccountInfo($data);
-        $this->assertInstanceOf('Ideneal\OpenLoad\Entity\AccountInfo', $account);
+        $this->assertInstanceOf(AccountInfo::class, $account);
         $this->assertEquals('admin@openload.co', $account->getEmail());
         $this->assertEquals('extuserid', $account->getId());
-        $this->assertInstanceOf('\DateTime', $account->getSignupDate());
+        $this->assertInstanceOf(\DateTime::class, $account->getSignupDate());
         $this->assertEquals(-1, $account->getStorageLeft());
         $this->assertEquals('32922117680', $account->getStorageUsed());
         $this->assertEquals(-1, $account->getTrafficLeft());
         $this->assertEquals(0, $account->getTrafficUsed24h());
         $this->assertEquals(0, $account->getBalance());
-   }
+    }
 }

--- a/tests/Builder/ContentBuilderTest.php
+++ b/tests/Builder/ContentBuilderTest.php
@@ -13,13 +13,15 @@ namespace Ideneal\OpenLoad\Test\Builder;
 
 use Ideneal\OpenLoad\Builder\ContentBuilder;
 use Ideneal\OpenLoad\Entity\File;
+use Ideneal\OpenLoad\Entity\Folder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * ContentBuilderTest
  *
  * @author Daniele Pedone aka Ideneal <ideneal.ztl@gmail.com>
  */
-class ContentBuilderTest extends \PHPUnit_Framework_TestCase
+class ContentBuilderTest extends TestCase
 {
     /**
      * @var string The folder result fixture
@@ -38,7 +40,7 @@ class ContentBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $data   = json_decode($this->folderFixture, true);
         $folder = ContentBuilder::buildFolder($data);
-        $this->assertInstanceOf('Ideneal\OpenLoad\Entity\Folder', $folder);
+        $this->assertInstanceOf(Folder::class, $folder);
     }
 
     /**
@@ -48,10 +50,10 @@ class ContentBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $data = json_decode($this->fileFixture, true);
         $file = ContentBuilder::buildFile($data);
-        $this->assertInstanceOf('Ideneal\OpenLoad\Entity\File', $file);
+        $this->assertInstanceOf(File::class, $file);
         $this->assertEquals('c6531f5ce9669d6547023d92aea4805b7c45d133', $file->getSha1());
         $this->assertEquals('4258', $file->getFolderId());
-        $this->assertInstanceOf('\DateTime', $file->getUploadDate());
+        $this->assertInstanceOf(\DateTime::class, $file->getUploadDate());
         $this->assertEquals('active', $file->getStatus());
         $this->assertEquals('5114011', $file->getSize());
         $this->assertEquals('video/mp4', $file->getContentType());

--- a/tests/Builder/ConversionStatusBuilderTest.php
+++ b/tests/Builder/ConversionStatusBuilderTest.php
@@ -12,13 +12,15 @@
 namespace Ideneal\OpenLoad\Test\Builder;
 
 use Ideneal\OpenLoad\Builder\ConversionStatusBuilder;
+use Ideneal\OpenLoad\Entity\ConversionStatus;
+use PHPUnit\Framework\TestCase;
 
 /**
  * ConversionStatusBuilderTest
  *
  * @author Daniele Pedone aka Ideneal <ideneal.ztl@gmail.com>
  */
-class ConversionStatusBuilderTest extends \PHPUnit_Framework_TestCase
+class ConversionStatusBuilderTest extends TestCase
 {
     /**
      * @var string The conversion status result fixture
@@ -32,11 +34,11 @@ class ConversionStatusBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $data   = json_decode($this->fixture, true);
         $status = ConversionStatusBuilder::buildConversionStatus($data);
-        $this->assertInstanceOf('Ideneal\OpenLoad\Entity\ConversionStatus', $status);
+        $this->assertInstanceOf(ConversionStatus::class, $status);
         $this->assertEquals('3565411', $status->getId());
         $this->assertEquals('Geysir.AVI', $status->getName());
         $this->assertEquals('pending', $status->getStatus());
-        $this->assertInstanceOf('\DateTime', $status->getLastUpdateDate());
+        $this->assertInstanceOf(\DateTime::class, $status->getLastUpdateDate());
         $this->assertEquals(0.32, $status->getProgress());
         $this->assertEquals('0', $status->getRetries());
         $this->assertEquals('https://openload.co/f/f02JFG293J8/Geysir.AVI', $status->getUrl());

--- a/tests/Builder/FileInfoBuilderTest.php
+++ b/tests/Builder/FileInfoBuilderTest.php
@@ -13,13 +13,14 @@ namespace Ideneal\OpenLoad\Test\Builder;
 
 use Ideneal\OpenLoad\Builder\FileInfoBuilder;
 use Ideneal\OpenLoad\Entity\FileInfo;
+use PHPUnit\Framework\TestCase;
 
 /**
  * FileInfoBuilderTest
  *
  * @author Daniele Pedone aka Ideneal <ideneal.ztl@gmail.com>
  */
-class FileInfoBuilderTest extends \PHPUnit_Framework_TestCase
+class FileInfoBuilderTest extends TestCase
 {
     /**
      * @var string The file info result fixture
@@ -33,7 +34,7 @@ class FileInfoBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $data     = json_decode($this->fixture, true);
         $fileInfo = FileInfoBuilder::buildFileInfo($data);
-        $this->assertInstanceOf('Ideneal\OpenLoad\Entity\FileInfo', $fileInfo);
+        $this->assertInstanceOf(FileInfo::class, $fileInfo);
         $this->assertEquals('72fA-_Lq8Ak3', $fileInfo->getId());
         $this->assertEquals('200', $fileInfo->getStatus());
         $this->assertEquals('The quick brown fox.txt', $fileInfo->getName());

--- a/tests/Builder/LinkBuilderTest.php
+++ b/tests/Builder/LinkBuilderTest.php
@@ -13,13 +13,15 @@ namespace Ideneal\OpenLoad\Test\Builder;
 
 use Ideneal\OpenLoad\Builder\LinkBuilder;
 use Ideneal\OpenLoad\Entity\DownloadLink;
+use Ideneal\OpenLoad\Entity\UploadLink;
+use PHPUnit\Framework\TestCase;
 
 /**
  * LinkBuilderTest
  *
  * @author Daniele Pedone aka Ideneal <ideneal.ztl@gmail.com>
  */
-class LinkBuilderTest extends \PHPUnit_Framework_TestCase
+class LinkBuilderTest extends TestCase
 {
     /**
      * @var string The upload link result fixture
@@ -38,8 +40,8 @@ class LinkBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $data       = json_decode($this->uploadFixture, true);
         $uploadLink = LinkBuilder::buildUploadLink($data);
-        $this->assertInstanceOf('Ideneal\OpenLoad\Entity\UploadLink', $uploadLink);
-        $this->assertInstanceOf('\DateTime', $uploadLink->getExpirationDate(new \DateTime('2011-01-26 13:33:37')));
+        $this->assertInstanceOf(UploadLink::class, $uploadLink);
+        $this->assertInstanceOf(\DateTime::class, $uploadLink->getExpirationDate(new \DateTime('2011-01-26 13:33:37')));
         $this->assertEquals('https://13abc37.example.com/ul/fCgaPthr_ys', $uploadLink->getUrl());
     }
 
@@ -50,12 +52,12 @@ class LinkBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $data         = json_decode($this->downloadFixture, true);
         $downloadLink = LinkBuilder::buildDownloadLink($data);
-        $this->assertInstanceOf('Ideneal\OpenLoad\Entity\DownloadLink', $downloadLink);
+        $this->assertInstanceOf(DownloadLink::class, $downloadLink);
         $this->assertEquals('The quick brown fox.txt', $downloadLink->getName());
         $this->assertEquals(12345, $downloadLink->getSize());
         $this->assertEquals('2fd4e1c67a2d28fced849ee1bb76e7391b93eb12', $downloadLink->getSha1());
         $this->assertEquals('plain/text', $downloadLink->getContentType());
-        $this->assertInstanceOf('\DateTime', $downloadLink->getUploadDate());
+        $this->assertInstanceOf(\DateTime::class, $downloadLink->getUploadDate());
         $this->assertEquals('4spxX_-cSO4', $downloadLink->getToken());
         $this->assertEquals('https://abvzps.example.com/dl/l/4spxX_-cSO4/The+quick+brown+fox.txt', $downloadLink->getUrl());
     }

--- a/tests/Builder/RemoteUploadBuilderTest.php
+++ b/tests/Builder/RemoteUploadBuilderTest.php
@@ -13,13 +13,15 @@ namespace Ideneal\OpenLoad\Test\Builder;
 
 use Ideneal\OpenLoad\Builder\RemoteUploadBuilder;
 use Ideneal\OpenLoad\Entity\RemoteUpload;
+use Ideneal\OpenLoad\Entity\RemoteUploadStatus;
+use PHPUnit\Framework\TestCase;
 
 /**
  * RemoteUploadBuilderTest
  *
  * @author Daniele Pedone aka Ideneal <ideneal.ztl@gmail.com>
  */
-class RemoteUploadBuilderTest extends \PHPUnit_Framework_TestCase
+class RemoteUploadBuilderTest extends TestCase
 {
     /**
      * @var string The remote upload result fixture
@@ -38,7 +40,7 @@ class RemoteUploadBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $data   = json_decode($this->fixtureUpload, true);
         $upload = RemoteUploadBuilder::buildRemoteUpload($data);
-        $this->assertInstanceOf('Ideneal\OpenLoad\Entity\RemoteUpload', $upload);
+        $this->assertInstanceOf(RemoteUpload::class, $upload);
         $this->assertEquals('4248', $upload->getFolderId());
     }
 
@@ -49,14 +51,14 @@ class RemoteUploadBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $data   = json_decode($this->fixtureStatus, true);
         $status = RemoteUploadBuilder::buildRemoteUploadStatus($data);
-        $this->assertInstanceOf('Ideneal\OpenLoad\Entity\RemoteUploadStatus', $status);
-        $this->assertInstanceOf('Ideneal\OpenLoad\Entity\RemoteUpload', $status->getRemoteUpload());
+        $this->assertInstanceOf(RemoteUploadStatus::class, $status);
+        $this->assertInstanceOf(RemoteUpload::class, $status->getRemoteUpload());
         $this->assertEquals('http://proof.ovh.net/files/100Mio.dat', $status->getRemoteUrl());
         $this->assertEquals('new', $status->getStatus());
         $this->assertNull($status->getBytesLoaded());
         $this->assertNull($status->getBytesTotal());
-        $this->assertInstanceOf('\DateTime', $status->getAddedDate());
-        $this->assertInstanceOf('\DateTime', $status->getLastUpdateDate());
+        $this->assertInstanceOf(\DateTime::class, $status->getAddedDate());
+        $this->assertInstanceOf(\DateTime::class, $status->getLastUpdateDate());
         $this->assertFalse($status->getFileId());
         $this->assertFalse($status->getUrl());
     }

--- a/tests/Builder/TicketBuilderTest.php
+++ b/tests/Builder/TicketBuilderTest.php
@@ -14,13 +14,15 @@ namespace Ideneal\OpenLoad\Test\Builder;
 use Ideneal\OpenLoad\Builder\CaptchaBuilder;
 use Ideneal\OpenLoad\Builder\TicketBuilder;
 use Ideneal\OpenLoad\Entity\Ticket;
+use Ideneal\OpenLoad\Entity\Captcha;
+use PHPUnit\Framework\TestCase;
 
 /**
  * TicketBuilderTest
  *
  * @author    Daniele Pedone aka Ideneal <ideneal.ztl@gmail.com>
  */
-class TicketBuilderTest extends \PHPUnit_Framework_TestCase
+class TicketBuilderTest extends TestCase
 {
     /**
      * @var string The ticket result fixture
@@ -34,11 +36,11 @@ class TicketBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $data   = json_decode($this->fixture, true);
         $ticket = TicketBuilder::buildTicket($data);
-        $this->assertInstanceOf('Ideneal\OpenLoad\Entity\Ticket', $ticket);
+        $this->assertInstanceOf(Ticket::class, $ticket);
         $this->assertEquals('72fA-_Lq8Ak~~1440353112~n~~0~nXtN3RI-nsEa28Iq', $ticket->getCode());
-        $this->assertInstanceOf('Ideneal\OpenLoad\Entity\Captcha', $ticket->getCaptcha());
+        $this->assertInstanceOf(Captcha::class, $ticket->getCaptcha());
         $this->assertEquals(10, $ticket->getWaitTime());
-        $this->assertInstanceOf('\DateTime', $ticket->getExpirationDate());
+        $this->assertInstanceOf(\DateTime::class, $ticket->getExpirationDate());
     }
 
     /**
@@ -48,7 +50,7 @@ class TicketBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $data    = json_decode($this->fixture, true);
         $captcha = CaptchaBuilder::buildCaptcha($data['captcha_url'], $data['captcha_w'], $data['captcha_h']);
-        $this->assertInstanceOf('Ideneal\OpenLoad\Entity\Captcha', $captcha);
+        $this->assertInstanceOf(Captcha::class, $captcha);
         $this->assertEquals('https://openload.co/dlcaptcha/b92eY_nfjV4.png', $captcha->getUrl());
         $this->assertEquals(140, $captcha->getWidth());
         $this->assertEquals(70, $captcha->getHeight());
@@ -71,6 +73,6 @@ class TicketBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $ticket = new Ticket();
         $ticket->setCode('72fA-_Lq8Ak~~1440353112~n~~0~nXtN3RI-nsEa28Iq');
-        $this->assertEquals('72fA-_Lq8Ak~~1440353112~n~~0~nXtN3RI-nsEa28Iq', $ticket);    
+        $this->assertEquals('72fA-_Lq8Ak~~1440353112~n~~0~nXtN3RI-nsEa28Iq', $ticket);
     }
 }


### PR DESCRIPTION
# Changed log
- It's time to use the class-based PHPUnit namespace to be compatible with the latest PHPUnit version.
- Set the different PHPUnit version to support the different PHP versions.
- Using the `assertInstanceOf` method with assigning the correct expected object.

